### PR TITLE
Added delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ signal('itemDeleted', [
 ]);
 ```
 
+#### delay
+
+* `delay(time, continueChain)`
+
+```js
+signal('itemAdded', [
+  addItem,
+  delay(500, [
+    removeItemHighlight
+  ])
+]);
+```
+
 #### when
 
 When can be used to check input or state for a specific value, truthy or falsy and then run an action chain when the condition is matched. To check multiple paths, see the operators section below. If no `when.otherwise` condition is provided then an `otherwise` output path will be created for you.

--- a/src/delay.js
+++ b/src/delay.js
@@ -1,0 +1,18 @@
+export default function (time, continueChain) {
+  const delay = function delay (args) {
+    setTimeout(args.output.continue, time)
+  }
+
+  delay.async = true
+  delay.outputs = ['continue']
+  delay.displayName = `operators.delay(${time})`
+
+  if (continueChain) {
+    return [
+      delay, {
+        continue: continueChain
+      }
+    ]
+  }
+  return delay
+}

--- a/test/delay.js
+++ b/test/delay.js
@@ -1,0 +1,54 @@
+/*global beforeEach,afterEach,describe,it*/
+import delay from '../src/delay'
+import { reset, check, expect } from './helpers/chaiCounter'
+import controller from './helpers/controller'
+
+function increaseCount ({ state }) {
+  state.set('count', state.get('count') + 1)
+}
+
+controller.addSignals({
+  increase: {
+    chain: [delay(5), {continue: [increaseCount]}],
+    immediate: true
+  },
+  withFactory: {
+    chain: delay(5, [increaseCount]),
+    immediate: true
+  }
+})
+
+const signals = controller.getSignals()
+let tree
+
+beforeEach(reset)
+afterEach(check)
+
+describe('delay()', function () {
+  beforeEach(function () {
+    tree = controller.model.tree
+    tree.set({
+      count: 0
+    })
+    tree.commit()
+  })
+
+  it('should not call increase before delay is done', function (done) {
+    signals.increase()
+    expect(tree.get('count')).to.equal(0)
+
+    setTimeout(function () {
+      expect(tree.get('count')).to.equal(1)
+      done()
+    }, 10)
+  })
+  it('should not call increase before delay is done, using factory', function (done) {
+    signals.withFactory()
+    expect(tree.get('count')).to.equal(0)
+
+    setTimeout(function () {
+      expect(tree.get('count')).to.equal(1)
+      done()
+    }, 10)
+  })
+})


### PR DESCRIPTION
Delay is a good operator to handle for example highlighting. For example when you add something to a list you might want to highlight it when it is added and then 500ms later you want to change the state of the item to not be highlighted: 

``` js
[
  addItem,
  [
    postItem, {
      success: [
        updateItemWithId
      ]
    },
    delay(500), {
      continue: [removeItemHighlight]
    }
  ]
]
```
