### PR TITLE
refactor: add ponyfill for Symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "watch": "^0.19.1"
   },
   "dependencies": {
-    "cerebral-scheme-parser": "^0.1.1"
+    "cerebral-scheme-parser": "^0.1.1",
+    "es6-symbol": "^3.1.0"
   }
 }

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,3 +1,4 @@
+import Symbol from 'es6-symbol'
 const pending = {}
 
 export default function (time = 100, acceptedChain = null, options = null) {

--- a/src/when.js
+++ b/src/when.js
@@ -1,3 +1,4 @@
+import Symbol from 'es6-symbol'
 import parseScheme from 'cerebral-scheme-parser'
 import populateInputAndStateSchemes from './helpers/populateInputAndStateSchemes'
 const truthy = Symbol('truthy')


### PR DESCRIPTION
Symbol does not exist in some browsers, so it is safer to run a ponyfill. This will
return the native Symbol if it exists, or a polyfill if it does not.
